### PR TITLE
Sorting the event mask

### DIFF
--- a/ProjectSutro/ProjectSutro/Main App View/Filter View/FilterView.swift
+++ b/ProjectSutro/ProjectSutro/Main App View/Filter View/FilterView.swift
@@ -424,7 +424,10 @@ struct FilterView: View {
                             
                             GroupBox {
                                 VStack(alignment: .leading, spacing: 8) {
-                                    ForEach(eventFilterSearch, id: \.self) { event in
+                                    ForEach(
+                                        eventFilterSearch.sorted(),
+                                        id: \.self
+                                    ) { event in
                                         GroupBox {
                                             HStack {
                                                 Image(systemName: eventStringToImage(from: event))


### PR DESCRIPTION
The list of events loaded for the event mask is now sorted and appears in a deterministic order. 